### PR TITLE
Add capsicum community to hashtag injector

### DIFF
--- a/app/plugins/community_hashtag_injector/__init__.py
+++ b/app/plugins/community_hashtag_injector/__init__.py
@@ -17,7 +17,8 @@ COMMUNITY_HASHTAG_MAP = {
     17: ["precure_fun"],       #プリキュア
     38: ["DQ10", "DQX"],       #DQX
     67: ["PieFed"],            #PieFed JP
-    112: ["DQウォーク", "DQW"]  #DQW
+    112: ["DQウォーク", "DQW"],  #DQW
+    116: ["capsicum"],           #capsicum
 }
 
 def configured_communities_by_id():


### PR DESCRIPTION
## Summary

- Add capsicum community (ID 116) with hashtag `#capsicum` to the community hashtag injector plugin

## Reference

- https://pf.korako.me/c/capsicum